### PR TITLE
Matched input-field width with Zeplin design, centered input text, co…

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -96,6 +96,12 @@ $gainsboro: #e1e1e1;
   outline: none;
 }
 
+// .button-text > span {
+//   margin-left: 22px;
+//   display: flex;
+//   padding: 4px 0px;
+// }
+
 .Vector-7 > span {
   // width: 9.3px;
   // height: 18.7px;
@@ -133,16 +139,18 @@ $gainsboro: #e1e1e1;
 }
 .input-field {
   font-family: $raleway-regular;
-  font-size: 20px;
+  font-size: 40px;
   color: $jet;
-  width: 100%;
+  width: 650px;
+  text-align: center;
   border: 0;
   outline: none;
   transition: padding 0.3s 0.2s ease;
   border-bottom: solid 2px $jet;
 
+  //Do we need this?
   &:focus {
-    padding-bottom: 5px;
+    // padding-bottom: 5px;
   }
 
   &:focus + .line {


### PR DESCRIPTION
1) Centered input text on globals.scss line 145;
2) Matched input-field bottom border width to Zeplin design 650px;
3) Commented out line 153 scss.  Noticed that this adds 5px padding when user clicks input-field.  Not sure if we want to keep this as a feature or not.